### PR TITLE
Add length arg to ScatterSwap.reverse_hash too

### DIFF
--- a/lib/scatter_swap.rb
+++ b/lib/scatter_swap.rb
@@ -6,7 +6,7 @@ module ScatterSwap
     Hasher.new(plain_integer, spin, length).hash
   end
 
-  def self.reverse_hash(hashed_integer, spin = 0)
-    Hasher.new(hashed_integer, spin, hashed_integer.to_s.length).reverse_hash
+  def self.reverse_hash(hashed_integer, spin = 0, length = 10)
+    Hasher.new(hashed_integer, spin, length).reverse_hash
   end
 end

--- a/spec/scatter_swap_spec.rb
+++ b/spec/scatter_swap_spec.rb
@@ -23,8 +23,22 @@ describe "#hash" do
 
   it "should be reversable" do
     100.times do |integer|
-      hashed = ScatterSwap.hash(integer, 0, 1 + (integer / 10))
-      ScatterSwap.reverse_hash(hashed).to_i.should == integer
+      length = 1 + (integer / 10)
+      hashed = ScatterSwap.hash(integer, 0, length)
+      ScatterSwap.reverse_hash(hashed, 0, length).to_i.should == integer
+    end
+  end
+
+  context "When hashed_integer length is less than length used in ScatterSwap.hash" do
+    it "should be reversable" do
+      length = 20
+      integer = 2970439418180909067
+
+      hashed = ScatterSwap.hash(integer, 0, length)
+      # => "02792428384994356370"
+
+      ScatterSwap.reverse_hash(hashed, 0, length).to_i.should == integer
+      ScatterSwap.reverse_hash(hashed.to_i, 0, length).to_i.should == integer
     end
   end
 end


### PR DESCRIPTION
If integerized hashed integer is passed, can not reversible

e.g)

```ruby
ScatterSwap.hash(2970439418180909067, 0, 20)
=> "02792428384994356370"

ScatterSwap.reverse_hash("02792428384994356370", 0)
=> "02970439418180909067"

ScatterSwap.reverse_hash(2792428384994356370, 0)
=> "6564430356352013192"
```